### PR TITLE
修复getStatistics函数

### DIFF
--- a/utils/util.js
+++ b/utils/util.js
@@ -343,10 +343,21 @@ const getStatistics = (menu)=>{
     const query = wx.Bmob.Query('statistics')
     query.equalTo('menu','==',menu)
     query.find().then(res=>{
-      resolve({ 'result': res[0] })
+      if(res.length>0){
+        resolve({ 'result': res[0] })
+      }else{
+        query.set('menu', menu)
+        query.set('allScore', 0)
+        query.set('peopleNum', 0)
+        query.save().then(res2 => {
+          console.log(res2)
+          resolve({'result': res2})
+        })
+      }   
     })
   })
 }
+
 
 /**
  * 统计分数


### PR DESCRIPTION
项目初始化时statistics表为空，添加判断语句，在无相关记录情况下进行初始化，答题人数为0，总累计分为0