### PR TITLE
修复Countdown函数倒计时结束后不能正常调用handleClick

### DIFF
--- a/pages/answer/index.js
+++ b/pages/answer/index.js
@@ -155,6 +155,7 @@ Page({
     });
   },
   Countdown(time) {
+    var that = this
     //倒计时
     this.Countdown = new $wuxCountDown({
       date: +(new Date) + parseInt(time),


### PR DESCRIPTION
在外层添加语句var that = this 否则将导致函数调用出错